### PR TITLE
he cambiado el ej1 para usar el resumen directamente y salgan las siglas en vez del partido.

### DIFF
--- a/grupal.Rproj
+++ b/grupal.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: f9dcb0cc-fd9f-4666-beb0-5e623e0633e5
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/grupal.qmd
+++ b/grupal.qmd
@@ -29,7 +29,6 @@ library(extrafont)
 
 ------------------------------------------------------------------------
 
-
 ## Datos
 
 -   `election_data`: archivo con las elecciones al congreso
@@ -81,13 +80,11 @@ surveys <-
   filter(date_elec>'2008-1-1')
 ```
 
-
 ```{r}
 election_data <- 
   election_data |> 
   pivot_longer(cols = "BERDEAK-LOS VERDES":"COALICIÓN POR MELILLA", names_to = "partidos", values_to = "votos", values_drop_na = TRUE )
 ```
-
 
 ------------------------------------------------------------------------
 
@@ -173,17 +170,60 @@ resumen_2 <-
 
 ```{r}
 ganadores <- 
-  election_data |> 
+  resumen |> 
   filter(censo > 100000) |> 
   group_by(anno, id_municipio) |> 
   arrange(desc(votos)) |> 
   slice(1) |>  
-  summarise(partido_ganador = partidos,
+  summarise(partido_ganador = siglas,
             max_votos = votos,
             censo_municipio = censo) |> 
   ungroup()
 
 ganadores
+```
+
+=======
+
+Añadimos gráfico de España con municipios de más de 100k habitantes
+
+coloreados por los partidos que ganaron las elecciones en cada uno de los años electorales
+
+```{r}
+
+library(mapSpain)
+
+mapa_mas100k_ganadores<-
+mapSpain::esp_get_munic() |> 
+    left_join(ganadores, by=c("LAU_CODE"="id_municipio")) |> 
+    filter(anno=="2016")
+
+ggplot(mapa_mas100k_ganadores)+
+  geom_sf(aes(fill=partido_ganador),alpha=0.7, color="grey")+
+  scale_fill_manual(
+    #escogemos los colores correspondientes a los logos de cada partido
+    values=c("PP"="#1A4CA0",
+              "UP"="#542C85",
+              "PSOE"="#D50000",
+              "PNV"="#018B3F",
+              "Cs"="#EB6109",
+              "ERC"="#FFCD00",
+              "CIU"="#1E3A5F",
+              "MP"="#5A9A6E",
+              "VOX"="#1D7A2A",
+              "BNG"="#007A33",
+              "EH-BILDU"="#4C9A2A",
+              "OTROS"="pink",
+              "NA"="gray"),
+              na.value = "gray" )+
+  theme_minimal()+
+  labs(fill="partido_ganador",
+       title="Partidos ganadores en municipios de más de cien mil habitantes")+
+  theme(plot.title = element_text(hjust = 0.5),
+        legend.position = "bottom") # +
+  #facet_wrap(~ anno)
+
+
 ```
 
 ### Pregunta_2
@@ -277,8 +317,7 @@ ggplot(segundos,
 
 ### Pregunta_4
 
-¿Cómo analizar la relación entre censo y voto? ¿Es cierto que
-determinados partidos ganan en las zonas rurales?
+¿Cómo analizar la relación entre censo y voto? ¿Es cierto que determinados partidos ganan en las zonas rurales?
 
 ```{r}
 
@@ -315,48 +354,5 @@ determinados partidos ganan en las zonas rurales?
 ### Pregunta_9
 
 ```{r}
-
-```
-
-=======
-
-Añadimos gráfico de España con municipios de más de 100k habitantes
-
-coloreados por los partidos que ganaron las elecciones en cada uno de los años electorales
-
-```{r}
-
-install.packages("mapSpain")
-library(mapSpain)
-mapa_mas100k_ganadores<-
-mapSpain::esp_get_munic() |> 
-    left_join(ganadores, by=c("LAU_CODE"="id_municipio")) |> 
-    filter(anno=="2016")
-
-ggplot(mapa_mas100k_ganadores)+
-  geom_sf(aes(fill=partido_ganador),alpha=0.7, color="grey")+
-  scale_fill_manual(
-    #escogemos los colores correspondientes a los logos de cada partido
-    values=c("PP"="#1A4CA0",
-              "UP"="#542C85",
-              "PSOE"="#D50000",
-              "PNV"="#018B3F",
-              "Cs"="#EB6109",
-              "ERC"="#FFCD00",
-              "CIU"="#1E3A5F",
-              "MP"="#5A9A6E",
-              "VOX"="#1D7A2A",
-              "BNG"="#007A33",
-              "EH-BILDU"="#4C9A2A",
-              "OTROS"="pink",
-              "NA"="gray"),
-              na.value = "gray" )+
-  theme_minimal()+
-  labs(fill="partido_ganador",
-       title="Partidos ganadores en municipios de más de cien mil habitantes")+
-  theme(plot.title = element_text(hjust = 0.5),
-        legend.position = "bottom")
-#+
-  #facet_wrap(~ anno)
 
 ```


### PR DESCRIPTION
solo cambie lo de mi ejercicio y he cambiado de sitio lo de los mapas que hizo Javier para que esté justo después del ej1 ya que a eso corresponde. Para agrupar los partidos me parece mejor la primera manera, es más corta y a mi parecer se entiende mejor. Del ejercicio 2 el de el gráfico me parece mejor para contestar.